### PR TITLE
Get TravisCI building successfully

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,6 @@ android:
 
 notifications:
   slack: snackpackgames:w4sj03P0QwSiGYWye0Sm0J6t
+
+  before_install:
+   - chmod +x gradlew

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,11 @@ notifications:
     slack: snackpackgames:w4sj03P0QwSiGYWye0Sm0J6t
 
 before_install:
+#   Give gradlew execute permissions
     - chmod +x gradlew
+#   Create and Start Android emulator and wait until it's ready.
+    - echo no | android create avd --force -n test -t android-22 --abi armeabi-v7a
+    - emulator -avd test -no-skin -no-audio -no-window &
+    - android-wait-for-emulator
+    - adb shell input keyevent 82 &
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: android
+android:
+    components:
+        - build-tools-22.0.1
+        - android-22
+
+notifications:
+  slack: snackpackgames:w4sj03P0QwSiGYWye0Sm0J6t

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
 language: android
 android:
     components:
+        - platform-tools
+        - tools
         - build-tools-22.0.1
         - android-22
+        - extra
 
 notifications:
     slack: snackpackgames:w4sj03P0QwSiGYWye0Sm0J6t

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,11 @@
 language: android
+cache: false
+sudo: false
+env:
+    global:
+        # Solution to tests failing with ShellCommandUnresponsiveException from here:
+        # http://stackoverflow.com/questions/28949722/android-tests-fail-on-travis-with-shellcommandunresponsiveexception/28949723#28949723
+        - ADB_INSTALL_TIMEOUT=10 # minutes (2 minutes by default)
 android:
     components:
         - platform-tools
@@ -14,9 +21,11 @@ notifications:
 before_install:
 #   Give gradlew execute permissions
     - chmod +x gradlew
-#   Create and Start Android emulator and wait until it's ready.
+#   Install android emulator
     - echo no | android create avd --force -n test -t android-22 --abi armeabi-v7a
+
+before_script:
+#   Start and wait for emulator
     - emulator -avd test -no-skin -no-audio -no-window &
     - android-wait-for-emulator
     - adb shell input keyevent 82 &
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ android:
         - android-22
 
 notifications:
-  slack: snackpackgames:w4sj03P0QwSiGYWye0Sm0J6t
+    slack: snackpackgames:w4sj03P0QwSiGYWye0Sm0J6t
 
-  before_install:
-   - chmod +x gradlew
+before_install:
+    - chmod +x gradlew

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ android:
         - build-tools-22.0.1
         - android-22
         - extra
+        - sys-img-armeabi-v7a-android-22
 
 notifications:
     slack: snackpackgames:w4sj03P0QwSiGYWye0Sm0J6t


### PR DESCRIPTION
# Overview

These changes get TravisCI building and running tests on our codebase successfully. I had to do a lot of tweaking of `.travis.yml` to get it all running correctly, but it should build and run successfully from now on as long as the build process doesn't change.
## Changes
- Added `.travis.yml` with build configuration
- Fixed a bug where `gradlew` didn't have execution privileges in the TravisCI env
- Set up an emulator to run tests on TravisCI
